### PR TITLE
Remove showAttack method

### DIFF
--- a/src/main/java/techmod/mobs/MachinistHumanMob.java
+++ b/src/main/java/techmod/mobs/MachinistHumanMob.java
@@ -105,15 +105,6 @@ public class MachinistHumanMob extends HumanShop {
 
     }
 
-    public void showAttack(int x, int y, int seed, boolean showAllDirections) {
-        super.showAttack(x, y, seed, showAllDirections);
-        if (this.isClient() && this.customShowAttack == null) {
-            SoundManager.playSound(GameResources.swing1, SoundEffect.effect(this));
-        }
-
-    }
-
-
     public List<InventoryItem> getRecruitItems(ServerClient client) {
         if (this.isSettler()) {
             return null;


### PR DESCRIPTION
The class variable, `customShowAttack` does not exist anymore in the newer versions. I checked the other mob classes like `HunterHumanMob` and `GunsmithHumanMob` which this class is based on and which also had the same `this.customShowAttack == null` checks. In the newer versions, the entire `showAttack` method is gone so I opted to removing the entire method here as well.

I tested by spawning a Machinist Human and a random enemy, then observing the human attacking the mob. I can verify that the swing sounds play on attack.